### PR TITLE
Automate the boring stuff with.. GitHub!

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,32 @@
+# Pull Request labeler configuration
+# Not to be confused with `labels.yml` which contains the actual labels
+#
+# Format:
+# [label_name]:
+#   - [file paths/globs]
+
+# Note: There are no rules for the main source files!
+# This is intended, for now. Consideration will be given on how to
+# handle these as we determine how everything is working together.
+# I may set up a generic rule to apply a 'triage' label to everything
+# not labeled by our rules.
+
+documentation:
+  - '*.md' # Begins with a special char (*), so much be in quotes
+  - doc/*
+  - LICENSE
+
+repo:
+  - .github/*
+  - .github/**/*
+  - .gitignore
+  - .travis.yml
+
+tests:
+  - tests/*
+
+packaging:
+  - MANIFEST.in
+  - requirements.txt
+  - requirements_dev.txt
+  - setup.py

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -36,6 +36,12 @@
 - color: 0075ca
   name: documentation
   description: Improvements or additions to documentation
+- color: e8aa74
+  name: tests
+  description: Related to unit tests, integration tests, and the like
+- color: 99dde8
+  name: repo
+  description: Repository-related such as actions, contrib guidelines, etc
 
 # Project specific labels
 #  - Is there a way to pull in an external file here?

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -36,13 +36,13 @@
 - color: 0075ca
   name: documentation
   description: Improvements or additions to documentation
-- color: e8aa74
+- color: edbc91
   name: tests
   description: Related to unit tests, integration tests, and the like
-- color: 99dde8
+- color: cc5620
   name: repo
   description: Repository-related such as actions, or other Git-related things
-- color: e5d35e
+- color: aca1dd
   name: packaging
   description: Packaging, and distribution
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,43 @@
+# Labels listing used with 'micnncim/action-label-syncer'
+#
+# GitHub Default Labels
+#  - Do not modify. If so, they will be modified when the action
+#  runs. Is that what you want?
+- color: d73a4a
+  name: bug
+  description: Something isn't working
+- color: cfd3d7
+  name: duplicate
+  description: This issue or pull request already exists
+- color: a2eeef
+  name: enhancement
+  description: New feature or request
+- color: 7057ff
+  name: good first issue
+  description: Good for newcomers
+- color: 008672
+  name: help wanted
+  description: Extra attention is needed
+- color: e4e669
+  name: invalid
+  description: This doesn't seem right
+- color: d876e3
+  name: question
+  description: Further information is requested
+- color: ffffff
+  name: wontfix
+  description: This will not be worked on
+
+# Extra labels, common
+#  - Things added by me, common to all projects
+- color: a2ed89
+  name: discussion
+  description: Speak your mind
+- color: 0075ca
+  name: documentation
+  description: Improvements or additions to documentation
+
+# Project specific labels
+#  - Is there a way to pull in an external file here?
+#  - Might be a helpful way to add project specifics without updating
+#  this file directly.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -41,7 +41,10 @@
   description: Related to unit tests, integration tests, and the like
 - color: 99dde8
   name: repo
-  description: Repository-related such as actions, contrib guidelines, etc
+  description: Repository-related such as actions, or other Git-related things
+- color: e5d35e
+  name: packaging
+  description: Packaging, and distribution
 
 # Project specific labels
 #  - Is there a way to pull in an external file here?

--- a/.github/workflows/label_sync.yml
+++ b/.github/workflows/label_sync.yml
@@ -1,0 +1,26 @@
+# This workflow will be run on each push as a means to automatically
+# keep our desired Issue Labels to GitHub.
+#
+# Allows us to maintain a yml file of labels inside the repo, which
+# provides us the ability to easily transfer them to other projects,
+# and to automatically keep them in-sync should I accidentally change
+# something via the web interface and want it back.
+name: Label Synchronizer
+on:
+  push:
+    # Uncommenting below will prevent this action from running
+    # if the path listed below is the only file updated by this push.
+    #paths-ignore:
+    #  - ".github/labels.yml"
+
+jobs:
+  sync_labels:
+    name: Sync Labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+# GitHub action to automatically label pull requests based on
+# a set of rules defined in `.github/labeler.yml`
+#
+# This will run as a cronjob instead of per PR received. This is
+# due to limitations with GitHub and not having write access when
+# the action is executed from a fork of this repo.
+name: Periodic Labeler
+on:
+  schedule:
+    # Run every 12 hours. Tweak this to taste.
+    - cron: '* */12 * * *'
+jobs:
+  pull_request_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: paulfantom/periodic-labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,58 @@
+# This workflow handles some basic checks to be run on each push
+# to this repository. This includes any code style checks, or
+# testing (not including Travis CI!) that we may want to automate.
+name: Push Checks
+
+# Controls when the action will run. Triggers the workflow on push events
+# to any branch. Uncomment below to select specific branches.
+on:
+  push:
+    #branches: [ master ]
+
+# The file represents a workflow, which is made up of the jobs below.
+# Jobs can run sequentially or in parallel. In this case, our first job
+# is named 'code_lint', and uses the latest Ubuntu runner available.
+jobs:
+  code_lint:
+    name: Code Lint
+    runs-on: ubuntu-latest
+
+    # Steps represent the sequence of tasks making up your job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE
+    - uses: actions/checkout@v2
+
+    # Grab the latest minor version Python.
+    # As long as we get Python >= 3.6, it should be fine.
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+
+    # Not really necessary, but I want to ensure we can check the
+    # Python version in the action output.
+    - name: Python version check
+      run: |
+        import sys
+        print(sys.version)
+      shell: python
+
+    # We are only running flake8, therefore we don't need to install
+    # the full word_tools requirements.
+    - name: Install job dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+
+    # Run flake8, a failure exit code will cause the workflow to abort
+    # I think, at least.
+    #
+    # Thinking about this more, it may not actually abort the push.
+    # It will probably run as a check and the output shown as pass/fail
+    # to truly abort or refuse a commit, we would use proper git hooks.
+    - name: Lint with flake8
+      run: |
+        # Stop the push if there are Python syntax errors, or undefined names
+        flake8 word_tools tests --count --select=E9,F63,F7,F82 --show-source --statistic
+        # Exit-zero arg treats errors as warnings, so they don't stop the push
+        flake8 word_tools tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,15 +27,7 @@ jobs:
     - name: Set up Python 3.x
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
-
-    # Not really necessary, but I want to ensure we can check the
-    # Python version in the action output.
-    - name: Python version check
-      run: |
-        import sys
-        print(sys.version)
-      shell: python
+        python-version: '3.x'
 
     # We are only running flake8, therefore we don't need to install
     # the full word_tools requirements.


### PR DESCRIPTION
We can automate the boring stuff with Python, why not try it with GitHub as well? This pull request brings in a few smallish GitHub Actions to help automate parts of this repository. And of course, future repositories once everything is fully tested and broken out into a template for future use.

The reasoning behind this is simple. It looked cool. Being able to lint all push events, or automatically apply labels to pull requests is just an added bonus. At the time of writing this pull on GitHub, the additions include:

- Push checks in the form of `flake8` linting.
- Issue label synchronization with `.github/label.yml` on each push event.
- Periodic labelling of PRs based on paths updated in the branch.

Initially, as I pushed the periodic labelling action over, I thought there was a problem. I did not see any output from the action listed, and it does not show up in the list. Taking a minute to think this through, I am thinking that there simply is no output. Not yet anyway. The action is set to run every twelve hours so there could be a bit of waiting to do. In the name of testing, I will not apply any labels to this PR. If the action works, some time in the next twelve hours we should have some labels applied here.